### PR TITLE
chore: release v0.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,20 @@ All notable changes to this project will be documented in this file. See [conven
 
 - - -
 
+## [0.1.4](https://github.com/x-software-com/sancus/compare/v0.1.3...v0.1.4) - 2025-10-08
+
+### Other
+
+- add shell.nix
+- cargo update
+- *(deps)* bump clap from 4.5.40 to 4.5.48
+- *(deps)* bump anyhow from 1.0.98 to 1.0.100
+- *(deps)* bump crate-ci/typos from 1.34.0 to 1.37.2
+- *(deps)* bump serde_yaml_bw from 2.0.1 to 2.4.1
+- *(deps)* bump serde_json from 1.0.140 to 1.0.145
+- *(deps)* bump spdx from 0.10.8 to 0.12.0
+- *(deps)* bump actions/checkout from 4 to 5
+
 ## [0.1.3](https://github.com/x-software-com/sancus/compare/v0.1.2...v0.1.3) - 2025-07-07
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -452,7 +452,7 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "sancus"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sancus"
-version = "0.1.3"
+version = "0.1.4"
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/x-software-com/sancus/"
 repository = "https://github.com/x-software-com/sancus/"


### PR DESCRIPTION



## 🤖 New release

* `sancus`: 0.1.3 -> 0.1.4 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.4](https://github.com/x-software-com/sancus/compare/v0.1.3...v0.1.4) - 2025-10-08

### Other

- add shell.nix
- cargo update
- *(deps)* bump clap from 4.5.40 to 4.5.48
- *(deps)* bump anyhow from 1.0.98 to 1.0.100
- *(deps)* bump crate-ci/typos from 1.34.0 to 1.37.2
- *(deps)* bump serde_yaml_bw from 2.0.1 to 2.4.1
- *(deps)* bump serde_json from 1.0.140 to 1.0.145
- *(deps)* bump spdx from 0.10.8 to 0.12.0
- *(deps)* bump actions/checkout from 4 to 5
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).